### PR TITLE
Add priorDayLimit and priorEntryLimit

### DIFF
--- a/MMM-PaprikaMenu.js
+++ b/MMM-PaprikaMenu.js
@@ -141,15 +141,23 @@ Module.register("MMM-PaprikaMenu", {
         var reversed = sortedMenu.reverse();
         var filtered = [];
         var today = moment().startOf('day');
+        var entriesBeforeTodayCount = 0;
 
         for (var m of reversed) {
             var days = moment(m.raw_date).diff(today, 'days');
+
+            // If days < 0, this is a previous entry. The config may limit how many of these we show.
+            if (days < 0) {
+                entriesBeforeTodayCount++;
+            }
 
             // days is the number of days between today and this menu items date; a negative value for past items.
             // Add it to our result set if it is 0+ (today or in the future), and if this.config.priorDayLimit + days is 0+.
             // days >= 0 can just be rolled into the priorDayLimit check.
             // Example: priorDayLimit: 3, menu two days ago -> days: -2, 3 + -2 = 1, add it to the result.
-            if (this.config.priorDayLimit + days >= 0) {
+            //
+            // Additionally, only show max this.config.priorEntryLimit.
+            if (this.config.priorDayLimit + days >= 0 && this.config.priorEntryLimit >= entriesBeforeTodayCount) {
                 filtered.push(m);
             }
         }

--- a/MMM-PaprikaMenu.js
+++ b/MMM-PaprikaMenu.js
@@ -11,6 +11,7 @@ Module.register("MMM-PaprikaMenu", {
         email: "",
         password: "",
         weekStartsOnSunday: false,
+        showPriorDays: true,
         fadePriorEntries: true,
         showPictures: true,
         roundPictureCorners: false,
@@ -120,7 +121,25 @@ Module.register("MMM-PaprikaMenu", {
             });
         }
 
-        return formatted;
+        filtered = this.filterDaysAndEntries(formatted);
+        return filtered;
+    },
+
+    filterDaysAndEntries: function(sortedMenu) {
+        filtered = sortedMenu;
+
+        if (!this.config.showPriorDays) {
+            var today = moment().startOf('day');
+
+            filtered = [];
+            for (var m of sortedMenu) {
+                if (!moment(m.date, this.config.dateFormat).isBefore(today)) {
+                    filtered.push(m);
+                }
+            }
+        }
+
+        return filtered;
     },
 
     typeToMealDisplay: function(type) {

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ At a minimum, you need a Paprika cloud sync account. Provide that email and pass
 |email              |**REQUIRED**<br>The email/user account for Paprika<br><br>Type: *string*|
 |password           |**REQUIRED**<br>The password for your Paprika account<br><br>Type: *string*|
 |weekStartsOnSunday |The modules shows the current week's menu. If true, the first day of the week will be Sunday. If false, Monday.<br><br>Type: `bool`<br>Default: `false`|
+|showPriorDays      |Should previous days of this current week be display. If false, only today until the end of the week are shown.<br><br>Type: `bool`<br>Default: `true`|
 |fadePriorEntries   |Should entries from previous days in the current week be faded.<br><br>Type: `bool`<br>Default: `true`|
 |showPictures       |Show pictures corresponding to that days meal.<br><br>Type: `bool`<br>Default: `true`|
 |roundPictureCorners|Round the meal picture corners.<br><br>Type: `bool`<br>Default: `false`|

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ At a minimum, you need a Paprika cloud sync account. Provide that email and pass
 |email              |**REQUIRED**<br>The email/user account for Paprika<br><br>Type: *string*|
 |password           |**REQUIRED**<br>The password for your Paprika account<br><br>Type: *string*|
 |weekStartsOnSunday |The modules shows the current week's menu. If true, the first day of the week will be Sunday. If false, Monday.<br><br>Type: `bool`<br>Default: `false`|
-|showPriorDays      |Should previous days of this current week be display. If false, only today until the end of the week are shown.<br><br>Type: `bool`<br>Default: `true`|
+|priorDayLimit      |How many previous days of this current week will be display. If 0, only today until the end of the week are shown.<br><br>Type: `int`<br>Default: 7|
+|priorEntryLimit    |How many entries from previous days should be shown. _priorDayLimit_ takes precedence. For example, with 3 entries per day, _priorEntryLimit_ set to 5 and _priorDayLimit_ set to 1, you will only see 3 prior entries.<br><br>Type: `int`<br>Default:50|
 |fadePriorEntries   |Should entries from previous days in the current week be faded.<br><br>Type: `bool`<br>Default: `true`|
 |showPictures       |Show pictures corresponding to that days meal.<br><br>Type: `bool`<br>Default: `true`|
 |roundPictureCorners|Round the meal picture corners.<br><br>Type: `bool`<br>Default: `false`|

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ At a minimum, you need a Paprika cloud sync account. Provide that email and pass
 |email              |**REQUIRED**<br>The email/user account for Paprika<br><br>Type: *string*|
 |password           |**REQUIRED**<br>The password for your Paprika account<br><br>Type: *string*|
 |weekStartsOnSunday |The modules shows the current week's menu. If true, the first day of the week will be Sunday. If false, Monday.<br><br>Type: `bool`<br>Default: `false`|
-|priorDayLimit      |How many previous days of this current week will be display. If 0, only today until the end of the week are shown.<br><br>Type: `int`<br>Default: 7|
-|priorEntryLimit    |How many entries from previous days should be shown. _priorDayLimit_ takes precedence. For example, with 3 entries per day, _priorEntryLimit_ set to 5 and _priorDayLimit_ set to 1, you will only see 3 prior entries.<br><br>Type: `int`<br>Default:50|
+|priorDayLimit      |How many previous days of this current week will be displayed. If 0, only today until the end of the week are shown.<br><br>Type: `int`<br>Default: 7|
+|priorEntryLimit    |How many entries from previous days should be shown in total. _priorDayLimit_ takes precedence. For example, with 3 entries per day, _priorEntryLimit_ set to 5 and _priorDayLimit_ set to 1, you will only see 3 prior entries.<br><br>Type: `int`<br>Default: 50|
 |fadePriorEntries   |Should entries from previous days in the current week be faded.<br><br>Type: `bool`<br>Default: `true`|
 |showPictures       |Show pictures corresponding to that days meal.<br><br>Type: `bool`<br>Default: `true`|
 |roundPictureCorners|Round the meal picture corners.<br><br>Type: `bool`<br>Default: `false`|

--- a/node_helper.js
+++ b/node_helper.js
@@ -149,12 +149,13 @@ module.exports = NodeHelper.create({
         meals = [];
         var startOfWeek = this.getFirstDayOfWeek(weekStartsOnSunday);
         var nextWeek = startOfWeek.clone().add(7, 'days');
+        var lastDayOfWeek = nextWeek.clone().subtract(1, 'days');
 
         console.log('MMM-PaprikaMenu: Week starts: ' + startOfWeek.format('YYYY-MM-DD') + ', next week starts: ' + nextWeek.format('YYYY-MM-DD'));
 
         raw.forEach(function(item) {
             var itemDate = moment(item.date);
-            if (!(itemDate.isBefore(startOfWeek) || itemDate.isAfter(nextWeek))) {
+            if (!(itemDate.isBefore(startOfWeek) || itemDate.isAfter(lastDayOfWeek))) {
                 meals.push(item);
             }
         });


### PR DESCRIPTION
This change adds two new config options: `priorDayLimit` and `priorEntryLimit`. Each of these provide a way to limit the number of menu items display from days _before_ today.

The day limiter simply caps the number of days before today that are shown. For example, if you set it to 1 it will only show entries from the previous day.

The entry limiter counts the number of entries before today's, regardless of which day they are on. The count does respect the configurable sort order (counts in reverse).

You can combine these two options. In order to show a previous entry it has to be within both parameters, not just one.

Closes #4 